### PR TITLE
Added support to different authentication for every view

### DIFF
--- a/Controller/ApiDocController.php
+++ b/Controller/ApiDocController.php
@@ -23,7 +23,15 @@ class ApiDocController extends Controller
     public function indexAction($view = ApiDoc::DEFAULT_VIEW)
     {
         $extractedDoc = $this->get('nelmio_api_doc.extractor.api_doc_extractor')->all($view);
-        $htmlContent  = $this->get('nelmio_api_doc.formatter.html_formatter')->format($extractedDoc);
+        $config = $this->container->getParameter('nelmio_api_doc.sandbox.authentication_view');
+        if (isset($config[$view])) {
+            /** @var \Nelmio\ApiDocBundle\Formatter\HtmlFormatter $formatter */
+            $formatter = $this->get('nelmio_api_doc.formatter.html_formatter');
+            $formatter->setAuthentication($config[$view]);
+            $htmlContent  = $formatter->format($extractedDoc);
+        } else {
+            $htmlContent  = $this->get('nelmio_api_doc.formatter.html_formatter')->format($extractedDoc);
+        }
 
         return new Response($htmlContent, 200, array('Content-Type' => 'text/html'));
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -134,6 +134,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->booleanNode('entity_to_choice')->defaultTrue()->end()
+                        ->append($this->addAuthenticationViewNode())
                     ->end()
                 ->end()
                 ->arrayNode('swagger')
@@ -166,5 +167,63 @@ class Configuration implements ConfigurationInterface
             ->end();
 
         return $treeBuilder;
+    }
+
+    public function addAuthenticationViewNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('authentication_view');
+
+        $node
+            ->prototype('array')
+                ->children()
+                    ->scalarNode('delivery')
+                        ->isRequired()
+                        ->validate()
+                            ->ifNotInArray(array('query', 'http', 'header'))
+                            ->thenInvalid("Unknown authentication delivery type '%s'.")
+                        ->end()
+                    ->end()
+                    ->scalarNode('name')->isRequired()->end()
+                    ->enumNode('type')
+                        ->info('Required if http delivery is selected.')
+                        ->values(array('basic', 'bearer', 'hmac'))
+                    ->end()
+                    ->booleanNode('custom_endpoint')->defaultFalse()->end()
+                ->end()
+                ->validate()
+                    ->ifTrue(function ($v) {
+                        return 'http' === $v['delivery'] && !$v['type'] ;
+                    })
+                    ->thenInvalid('"type" is required when using http delivery.')
+                ->end()
+                # http_basic BC
+                ->beforeNormalization()
+                    ->ifTrue(function ($v) {
+                        return 'http_basic' === $v['delivery'];
+                    })
+                    ->then(function ($v) {
+                        $v['delivery'] = 'http';
+                        $v['type'] = 'basic';
+
+                        return $v;
+                    })
+                ->end()
+                ->beforeNormalization()
+                    ->ifTrue(function ($v) {
+                        return 'http' === $v['delivery'];
+                    })
+                    ->then(function ($v) {
+                        if ('http' === $v['delivery'] && !isset($v['name'])) {
+                            $v['name'] = 'Authorization';
+                        }
+
+                        return $v;
+                    })
+                ->end()
+            ->end()
+        ;
+
+        return $node;
     }
 }

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -56,6 +56,10 @@ class NelmioApiDocExtension extends Extension
             $container->setParameter('nelmio_api_doc.sandbox.authentication', $config['sandbox']['authentication']);
         }
 
+        if (isset($config['sandbox']['authentication_view'])) {
+            $container->setParameter('nelmio_api_doc.sandbox.authentication_view', $config['sandbox']['authentication_view']);
+        }
+
         // backwards compatibility for Symfony2.1 https://github.com/nelmio/NelmioApiDocBundle/issues/231
         if (!interface_exists('\Symfony\Component\Validator\MetadataFactoryInterface')) {
             $container->setParameter('nelmio_api_doc.parser.validation_parser.class', 'Nelmio\ApiDocBundle\Parser\ValidationParserLegacy');

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -657,7 +657,6 @@
                         if ('basic' == authentication_type) {
                             value = 'Basic ' + btoa($('#api_login').val() + ':' + $('#api_pass').val());
                         } else if ('bearer' == authentication_type) {
-                            api_key_parameter = 'Authorization';
                             value = 'Bearer ' + $('#api_key').val();
                         }
                     } else if ('header' == authentication_delivery) {


### PR DESCRIPTION
Now you can define more than one Authentication method:

```
nelmio_api_doc:
    sandbox:
        authentication:
            name: Authorization
            delivery: http          # `query`, `http`, and `header` are supported
            type:     bearer        # `basic`, `bearer` are supported
            custom_endpoint: false  # default is `false`, if `true`, your user will be able to

        .
        .
        .

        authentication_view:
            admin:                   
                name: ~                 
                delivery: header        
                type:     hmac          
                custom_endpoint: false  
```